### PR TITLE
Fix key error in case of no Telegram avatar

### DIFF
--- a/django_social_pill/pipeline.py
+++ b/django_social_pill/pipeline.py
@@ -53,7 +53,7 @@ def save_user_avatar(backend, user, response, *args, **kwargs):
         ext = 'jpg'
     elif backend.name == 'vk-oauth2':
         url = response['user_photo']
-    elif backend.name == 'telegram':
+    elif backend.name == 'telegram' and 'photo_url' in response:
         url = response['photo_url']
     if url:
         ext = ext or url.split('.')[-1]


### PR DESCRIPTION
Unlike other social networks, Telegram does not return url to the
default avatar.