### PR TITLE
https://github.com/vergeev/django_social_pill/commit/98802f4118334a927624f220d51ed8778df390bdBump social auth version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 requests==2.18.4
-social-auth-app-django==2.1.0
+social-auth-app-django==3.0.0


### PR DESCRIPTION
This fixes deprecated google plus API